### PR TITLE
ci(github): enrich chart release notes with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,54 @@ jobs:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  # Enrichit les notes des releases créées par chart-releaser avec un changelog
+  # git-cliff (commits conventionnels) entre la version courante de chaque chart
+  # et la précédente. N'altère ni le packaging ni la signature des charts.
+  release-notes:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install git-cliff
+        run: |
+          VERSION=2.13.1
+          curl -sSL "https://github.com/orhun/git-cliff/releases/download/v${VERSION}/git-cliff-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz
+          echo "${GITHUB_WORKSPACE}/git-cliff-${VERSION}-x86_64-unknown-linux-gnu" >> "$GITHUB_PATH"
+
+      - name: Enrich release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force --quiet
+          for chartdir in charts/*/; do
+            chart=$(basename "$chartdir")
+            version=$(grep -E '^version:' "$chartdir/Chart.yaml" | head -1 | awk '{gsub(/["\x27]/,"",$2); print $2}')
+            tag="${chart}-${version}"
+            if ! gh release view "$tag" >/dev/null 2>&1; then
+              echo "Pas de release pour $tag, on ignore."; continue
+            fi
+            # Tag de version précédente du MÊME chart (tri sémantique).
+            prev=""
+            mapfile -t vts < <(git tag --list "${chart}-*" --sort=version:refname)
+            for i in "${!vts[@]}"; do
+              if [ "${vts[$i]}" = "$tag" ] && [ "$i" -gt 0 ]; then prev="${vts[$((i-1))]}"; fi
+            done
+            if [ -z "$prev" ]; then
+              root=$(git rev-list --max-parents=0 "$tag" | tail -1); range="${root}..${tag}"
+            else
+              range="${prev}..${tag}"
+            fi
+            git-cliff --config cliff.toml "$range" --strip all > notes.md || true
+            [ -s notes.md ] || echo "_Pas de changement notable (commits ci/chore/docs uniquement)._" > notes.md
+            id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" --jq .id)
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${id}" -F "body=@notes.md" >/dev/null
+            echo "Notes mises à jour pour $tag (plage ${range})."
+          done

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,45 @@
+# Configuration git-cliff — utilisée à l'identique en CI (release.yml)
+# et en local (backfill). Génère des notes de release à partir des
+# commits conventionnels (feat:, fix:, ...) entre deux tags.
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# Pas d'en-tête : le titre de la Release GitHub est déjà le tag.
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first | trim }}{% if commit.scope %} *({{ commit.scope }})*{% endif %} (`{{ commit.id | truncate(length=7, end="") }}`)
+{%- endfor %}
+{% endfor %}"""
+trim = true
+footer = ""
+
+[git]
+# Analyse les commits conventionnels.
+conventional_commits = true
+# Ignore les commits non conventionnels.
+filter_unconventional = true
+split_commits = false
+# Catégorisation par type. `skip` masque le type des notes.
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->✨ Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^perf", group = "<!-- 2 -->🚀 Performance" },
+  { message = "^refactor", group = "<!-- 3 -->♻️ Refactors" },
+  { message = "^revert", group = "<!-- 4 -->⏪ Reverts" },
+  { message = "^docs?", skip = true },
+  { message = "^style", skip = true },
+  { message = "^test", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^build", skip = true },
+  { message = ".*", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+# Les tags ressemblent à 2.16.0 ou v2.16.0.
+tag_pattern = "v?[0-9]+\\.[0-9]+\\.[0-9]+"
+topo_order = false
+sort_commits = "newest"


### PR DESCRIPTION
## Résumé

Ajoute un changelog **git-cliff** (commits conventionnels) aux Releases de charts, **sans toucher** au pipeline chart-releaser ni à la signature GPG.

- ➕ `cliff.toml` : config partagée (identique à `platform`, `qalita-cli`, `qalita-core`).
- ➕ job `release-notes` (après `release`) : pour chaque chart publié, réécrit les notes de la Release entre la version courante et la précédente du **même chart**.

Les notes des Releases historiques (`qalita-*`, `seaweedfs-*`) sont par ailleurs reconstruites au même format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)