### PR TITLE
chore(charts/qalita): document worker image pin pending cli rename

### DIFF
--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for QALITA Platform, a platform for managing and monitoring your data quality.
 name: "qalita"
-version: "2.16.3"
+version: "2.16.4"
 icon: https://avatars.githubusercontent.com/u/101010687?s=48&v=4
 appVersion: "2.16.2"
 home: https://qalita.io

--- a/charts/qalita/values.yaml
+++ b/charts/qalita/values.yaml
@@ -167,6 +167,9 @@ worker:
   token: "changeme"
 
   image:
+    # Repo renamed qalita-cli -> cli on 2026-07-12; this default stays pinned
+    # to the legacy ghcr.io/qalita/qalita-cli package (prod-stable release)
+    # until the first tagged release exists under ghcr.io/qalita/cli.
     repository: ghcr.io/qalita/qalita-cli
     tag: "2.13.2"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Follow-up to the qalita-cli -> cli repo rename (2026-07-12, qalita/cli#87/#88, helm-website#11).

- Documents why `worker.image.repository` still defaults to the legacy `ghcr.io/qalita/qalita-cli` package: no tagged release exists yet under `ghcr.io/qalita/cli`, and prod (qalita-platform-dev.../prod) relies on this default's pinned tag `2.13.2`, which only exists in the legacy package.
- Chart-only version bump (2.16.3 -> 2.16.4), no functional change.

Companion: helm-website dev-values.yaml now explicitly overrides `worker.image.repository: ghcr.io/qalita/cli` for the dev environment, since dev tracks the `dev` tag (which the just-merged qalita/cli#88 makes build under the new name).