### PR TITLE
ci: pin Helm to 3.18.2 in setup-helm

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.0
+        with:
+          version: "3.18.2"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v5.0.0
+        with:
+          version: "3.18.2"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Pin `azure/setup-helm@v5.0.0` to Helm `3.18.2` in `ci-lint.yml` and `release.yml`
- Aligns with `qalita/platform` and `previly/helm`, which are already pinned to the same version
- Unpinned setup-helm installs the latest release, so the Helm version could change under the project without any commit showing it

## Test plan
- [ ] CI runs on this PR (ci-lint.yml) and installs Helm 3.18.2 successfully