### PR TITLE
feat(seaweedfs): chart 4.0.380 → 4.41.0 (phase 10 QALITA)

### DIFF
--- a/charts/qalita/Chart.lock
+++ b/charts/qalita/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.12.10
 - name: seaweedfs
   repository: https://seaweedfs.github.io/seaweedfs/helm
-  version: 4.0.380
-digest: sha256:6da0fc434e4d9874fd82d94575b578e0a98f57039986fb985843176cd2bfc0b2
-generated: "2026-01-13T14:05:31.785546991+01:00"
+  version: 4.41.0
+digest: sha256:82ba5b220ab4970b9cd2cfc0f34269422dcd1f6532033b913527cd4664b995f9
+generated: "2026-08-16T17:42:03.133084445+02:00"

--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -17,7 +17,10 @@ dependencies:
     condition: postgresql.enabled
   - name: seaweedfs
     repository: https://seaweedfs.github.io/seaweedfs/helm
-    version: 4.0.380
+    # 4.41.0 est la version de CHART ; elle livre l'appVersion 4.41, qui est
+    # ce que vise le socle. Les deux numéros se ressemblent sans être le même
+    # objet.
+    version: 4.41.0
     condition: seaweedfs.enabled
 maintainers:
   - name: qalita

--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for QALITA Platform, a platform for managing and monitoring your data quality.
 name: "qalita"
-version: "2.18.2"
+version: "2.19.0"
 icon: https://avatars.githubusercontent.com/u/101010687?s=48&v=4
 appVersion: "2.18.0"
 home: https://qalita.io

--- a/charts/qalita/README.md
+++ b/charts/qalita/README.md
@@ -8,6 +8,32 @@ This chart deploys QALITA Platform on a Kubernetes cluster using the Helm packag
 
 # Quick Start
 
+## Upgrading to 2.19.0 — SeaweedFS 4.41
+
+The bundled SeaweedFS chart moves from 4.0.380 (app 3.80) to 4.41.0 (app 4.41).
+Two values change, and **both must land together** — the chart bump alone
+renders an image that does not exist, and the values alone cannot reach 4.41
+because the old chart hard-codes its tag.
+
+**`seaweedfs.global.repository` is removed.** If you set it, delete it. The key
+never had any effect under the old chart, but SeaweedFS 4.41.0 revives it
+through a compatibility shim and it then doubles the image path
+(`ghcr.io/you/seaweedfs/seaweedfs:4.41`) with no rendering error. A value that
+used to be ignored now breaks your pull.
+
+**`seaweedfs.fullnameOverride` now defaults to `seaweedfs`.** SeaweedFS 4.41.0
+renames every object it creates to `<release>-seaweedfs-*`. Left to that
+default, an existing installation would orphan its `data-filer-*` and
+`data1-*` PersistentVolumeClaims — the data survives, but the S3 endpoint
+serves an empty store — and the upgrade would fail outright, since a
+StatefulSet's `spec.selector` is immutable. The override keeps the names you
+already have. **If you deliberately want the new naming**, set it to `""` and
+plan a data migration; do not do it in place.
+
+Requires **Helm >= 3.17.0** (the SeaweedFS chart uses `fromToml`). An older
+Helm fails with `function "fromToml" not defined`, which reads like a chart
+bug but is a tooling floor.
+
 ## Pre-requisites
 
 - Kubernetes `1.24+`

--- a/charts/qalita/values.schema.json
+++ b/charts/qalita/values.schema.json
@@ -400,7 +400,6 @@
             "createClusterRole": { "type": "boolean", "default": true },
             "serviceAccountName": { "type": "string", "default": "seaweedfs" },
             "registry": { "type": "string", "default": "ghcr.io/qalita" },
-            "repository": { "type": "string", "default": "seaweedfs" },
             "imagePullSecrets": { "type": ["string", "array"], "default": "qalita-platform-dockerregistry" },
             "imageName": { "type": "string", "default": "seaweedfs" }
           }

--- a/charts/qalita/values.yaml
+++ b/charts/qalita/values.yaml
@@ -239,11 +239,22 @@ postgresql:
 seaweedfs:
   enabled: true
 
+  # OBLIGATOIRE depuis le chart 4.41.0. 4.41.0 est passé de `seaweedfs.name` à
+  # `seaweedfs.componentName`, bâti sur `<Release.Name>-seaweedfs` : sans cette
+  # ligne TOUS les objets sont renommés, les PVC deviennent orphelins, et
+  # `spec.selector` d'un StatefulSet étant immuable, l'upgrade échoue.
+  fullnameOverride: "seaweedfs"
+
   global:
     createClusterRole: true
     serviceAccountName: "seaweedfs"
     registry: ghcr.io/qalita
-    repository: seaweedfs
+    # PAS de `repository:` ici. La clé existait et n'a JAMAIS rien fait : en
+    # chart 4.0.380 le helper d'image ne la lisait pas (c'était même écrit dans
+    # .github/workflows/mirror-images.yml). Le chart 4.41.0 la RESSUSCITE via
+    # son shim de compatibilité (_compat.tpl:27-31), et elle rend alors
+    # `ghcr.io/qalita/seaweedfs/seaweedfs:4.41` — chemin doublé, image
+    # inexistante, sans la moindre erreur au rendu. Mesuré le 2026-08-16.
     imagePullSecrets: "qalita-platform-dockerregistry"
     imageName: seaweedfs
 


### PR DESCRIPTION
## ⚠️ À fusionner **après** [qalita/helm-website#17](https://github.com/qalita/helm-website/pull/17)

La CI de `qalita/platform` checkoute les deux dépôts depuis `main` sans `ref:`.
Fusionner celle-ci en premier ouvre une fenêtre où tout déploiement rend
`ghcr.io/qalita/seaweedfs/seaweedfs:4.41` — image inexistante. La PR
helm-website est un no-op sous le chart actuel, donc sans risque à passer
d'abord.

## Deux changements, indissociables du bump

**1. `global.repository: seaweedfs` retiré** (values.yaml + values.schema.json).

Cette clé n'a jamais rien fait sous 4.0.380 — le helper d'image ne la lit pas.
4.41.0 la ressuscite via son shim (`_compat.tpl:27-31`). Mesuré :

```
4.41.0 AVEC global.repository : ghcr.io/qalita/seaweedfs/seaweedfs:4.41   (inexistante)
4.41.0 SANS global.repository : ghcr.io/qalita/seaweedfs:4.41             ✅
```

**2. `fullnameOverride: "seaweedfs"` ajouté.**

4.41.0 renomme tous les objets en `<release>-seaweedfs-*`. Sans cette ligne :
PVC orphelins, Services supprimés, et l'upgrade **échoue** — `spec.selector`
d'un StatefulSet est immuable. Rupture absente des notes amont.

Le bump seul ne suffit jamais : sur 4.0.380 le tag est codé en dur
(`_helpers.tpl:91`), donc aucune value ne peut viser 4.41 avant que le chart
ne bouge.

## Vérifié contre les trois environnements vivants

```
qalita-platform-dev    vivants=10  rendus=15  PERDUS=AUCUN
qalita-platform-demo   vivants=10  rendus=15  PERDUS=AUCUN
qalita-platform-prod   vivants=10  rendus=15  PERDUS=AUCUN

seaweedfs-filer   selector=IDENTIQUE  volumeClaimTemplates=IDENTIQUE
seaweedfs-master  selector=IDENTIQUE  volumeClaimTemplates=IDENTIQUE
seaweedfs-volume  selector=IDENTIQUE  volumeClaimTemplates=IDENTIQUE
```

## L'image du miroir a été déposée

`ghcr.io/qalita/seaweedfs:4.41` n'existait pas — le workflow de miroir échoue
en 403 parce que le package GHCR a été créé avec `repository: null` et refuse
le `GITHUB_TOKEN`. Copiée à la main le 2026-08-16, **multi-arch** :

| plateforme | digest identique à l'amont |
|---|---|
| linux/amd64 | ✅ |
| linux/arm64 | ✅ |
| linux/armv7 | ✅ |
| linux/386 | ✅ |

Le multi-arch n'est pas du confort : les masters sont épinglés **pi1 (arm64)**
et **contabo (amd64)**, une copie mono-arch en aurait cassé un.

**Reste à faire côté propriétaire**, hors de cette PR : lier le package
`qalita/seaweedfs` à `qalita/helm-platform` en **Write** (Package settings →
Manage Actions access), sinon le miroir hebdomadaire restera rouge et le
prochain tag devra encore être copié à la main.

## Répétition de restauration

Faite sur Previly, où la même montée est proposée
([previly/helm#17](https://github.com/previly/helm/pull/17)) : 60 objets
restaurés depuis une sauvegarde Longhorn hors-site, **SeaweedFS 4.41.0monté sur
des données écrites par 3.80**, inventaire et 8 SHA256 identiques. C'est ce qui
répond à la question de compatibilité des métadonnées, laissée ouverte jusque-là.

## Version et migration

Chart `2.18.2` → **`2.19.0`** — mineure, conformément à la pratique du dépôt
(le renommage worker était sorti en 2.17.0 → 2.18.0). Note de migration ajoutée
au README : les deux valeurs à changer, la clé qui devient nuisible, et le
plancher **helm ≥ 3.17.0** (`fromToml`).