### PR TITLE
fix(secrets): un déploiement sans identifiants ne doit plus en détruire

### DIFF
--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for QALITA Platform, a platform for managing and monitoring your data quality.
 name: "qalita"
-version: "2.19.0"
+version: "2.20.0"
 icon: https://avatars.githubusercontent.com/u/101010687?s=48&v=4
 appVersion: "2.18.0"
 home: https://qalita.io

--- a/charts/qalita/templates/_helpers.tpl
+++ b/charts/qalita/templates/_helpers.tpl
@@ -43,3 +43,82 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Valeur d'un champ de Secret, EN PRÉSERVANT CE QUI EXISTE DÉJÀ EN CLUSTER.
+
+Retourne la valeur EN CLAIR. L'appelant l'écrit dans `stringData` ; il ne doit
+pas la ré-encoder.
+
+POURQUOI CE HELPER EXISTE. Le 2026-08-17, un `helm upgrade` de
+qalita-platform-demo lancé avec le seul fichier de values a détruit deux
+Secrets d'un coup :
+  - seaweedfs-s3-secret : les quatre identifiants réécrits à VIDE, parce que
+    platform/demo-values.yaml déclare `backend.s3.*: ""` — ce sont des
+    emplacements que le pipeline remplit au déploiement, et le template les
+    recopiait tels quels. Le backend est tombé en boucle sur
+    « InvalidAccessKeyId », la passerelle S3 ne relisant sa configuration qu'au
+    démarrage ;
+  - qalita-qalita-secret : `secretKey` (signature JWT) et `adminPassword`
+    regénérés aléatoirement, parce qu'ils étaient rendus avec
+    `default (randAlphaNum N) .Values…` — un défaut qui rotait donc ces valeurs
+    à CHAQUE upgrade où elles n'étaient pas fournies, invalidant toutes les
+    sessions en cours.
+Le champ `licenseKey` du même Secret, lui, avait déjà le bon motif (`lookup`
+puis réutilisation) et a traversé l'incident intact. Ce helper généralise ce
+motif au lieu de le laisser à un seul champ.
+
+ORDRE DE RÉSOLUTION, du plus explicite au plus prudent :
+  1. la valeur fournie dans les values, si elle est non vide — c'est la
+     déclaration, elle prime toujours ;
+  2. sinon la valeur DÉJÀ PRÉSENTE dans le Secret en cluster — un déploiement
+     qui ne fournit pas un secret ne doit jamais en détruire un ;
+  3. sinon `default`, s'il est renseigné — pour les champs qui ont une valeur
+     de repli qui a un sens métier, comme `licenseKey` qui vaut « unlicenced »
+     tant qu'aucune licence n'est posée ;
+  4. sinon, si `generate` est vrai, une valeur aléatoire de `length`
+     caractères — uniquement au tout premier déploiement, quand il n'y a rien
+     à préserver ;
+  5. sinon `fail`, avec le nom du champ. Un déploiement qui ne peut pas
+     produire une valeur valide doit s'arrêter bruyamment, pas écrire du vide.
+
+ATTENTION AU MODE `helm template`. `lookup` y renvoie toujours vide : l'étape 2
+est donc inopérante, et un rendu hors cluster avec des values vides tombera en
+3 ou en 4. C'est voulu — `helm template` sert à inspecter, pas à déployer — mais
+cela veut dire qu'un test de non-régression sur la préservation doit passer par
+`helm upgrade --dry-run`, seul mode où `lookup` interroge réellement l'API.
+
+Arguments (dict) :
+  ctx       le contexte racine ($)
+  secret    nom du Secret en cluster
+  key       clé dans ce Secret
+  value     valeur issue des values (peut être vide ou nulle)
+  default   valeur de repli explicite (facultatif)
+  generate  booléen : générer une valeur aléatoire en dernier recours
+  length    longueur de la valeur générée
+*/}}
+{{- define "qalita.preservedSecret" -}}
+{{- $ctx := .ctx -}}
+{{- /* `default ""` avant `toString` : sur une valeur nulle, `toString` seul
+       rendrait la chaîne "<nil>", qui passerait pour une valeur fournie. */ -}}
+{{- $supplied := .value | default "" | toString -}}
+{{- if $supplied -}}
+{{- $supplied -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" $ctx.Release.Namespace .secret -}}
+{{- $prev := "" -}}
+{{- if and $existing $existing.data (hasKey $existing.data .key) -}}
+{{- $prev = index $existing.data .key | b64dec -}}
+{{- end -}}
+{{- $fallback := .default | default "" | toString -}}
+{{- if $prev -}}
+{{- $prev -}}
+{{- else if $fallback -}}
+{{- $fallback -}}
+{{- else if .generate -}}
+{{- randAlphaNum (.length | int) -}}
+{{- else -}}
+{{- fail (printf "Secret %s : le champ %s est vide et aucune valeur existante n'a ete trouvee dans le namespace %s. Fournissez-le (pipeline, Infisical, --set) plutot que de deployer avec un emplacement vide : ecrire une valeur vide ici casserait l'authentification." .secret .key $ctx.Release.Namespace) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/qalita/templates/qalita-secret.yaml
+++ b/charts/qalita/templates/qalita-secret.yaml
@@ -1,10 +1,39 @@
 {{- $secretName := printf "%s-qalita-secret" .Release.Name -}}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- /*
+  `adminPassword` et `secretKey` étaient rendus avec
+  `default (randAlphaNum N | b64enc) .Values… | b64enc`. Deux défauts dans cette
+  seule ligne :
+
+    - le tirage aléatoire était refait à CHAQUE rendu. Un `helm upgrade` qui ne
+      fournissait pas ces valeurs — le cas des fichiers de values du parc, qui
+      les déclarent à "" — les rotait donc silencieusement. Mesuré le
+      2026-08-17 sur qalita-platform-demo : `secretKey`, qui signe les JWT, a
+      changé pendant un upgrade destiné à SeaweedFS, invalidant toutes les
+      sessions en cours ;
+    - le `| b64enc` interne s'ajoutait à celui de fin, donc la valeur générée
+      était encodée DEUX fois. Trace de l'incident : 512 caractères tirés
+      devenaient 684 octets après décodage simple. Une valeur fournie, elle,
+      n'était encodée qu'une fois — les deux chemins ne produisaient pas le
+      même genre de contenu.
+
+  `qalita.preservedSecret` corrige les deux : la valeur fournie prime, sinon
+  celle déjà en cluster est réutilisée, sinon seulement on tire au sort — donc
+  au premier déploiement uniquement. On passe à `stringData` pour que l'encodage
+  n'ait plus lieu qu'à un seul endroit, celui de Kubernetes.
+
+  `licenseKey` avait déjà le bon comportement via `lookup` et a traversé
+  l'incident intact ; il est ici exprimé avec le même helper que les autres,
+  sans changement de sémantique — `unlicenced` reste le repli au premier
+  déploiement.
+*/}}
+{{- $adminPassword := include "qalita.preservedSecret" (dict "ctx" $ "secret" $secretName "key" "adminPassword" "value" .Values.backend.adminPassword "generate" true "length" 25) -}}
+{{- $secretKey     := include "qalita.preservedSecret" (dict "ctx" $ "secret" $secretName "key" "secretKey"     "value" .Values.backend.secretKey     "generate" true "length" 512) -}}
+{{- $licenseKey    := include "qalita.preservedSecret" (dict "ctx" $ "secret" $secretName "key" "licenseKey"    "value" .Values.licenseKey            "default" "unlicenced") -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ $secretName }}"
-data:
-  adminPassword: {{ default (randAlphaNum 25 | b64enc) .Values.backend.adminPassword | b64enc }}
-  secretKey: {{ default (randAlphaNum 512 | b64enc) .Values.backend.secretKey | b64enc }}
-  licenseKey: {{ if and $existingSecret (not .Values.licenseKey) }}{{ index $existingSecret.data "licenseKey" }}{{ else }}{{ default "unlicenced" .Values.licenseKey | b64enc }}{{ end }}
+stringData:
+  adminPassword: {{ $adminPassword | quote }}
+  secretKey: {{ $secretKey | quote }}
+  licenseKey: {{ $licenseKey | quote }}

--- a/charts/qalita/templates/seaweedfs-s3-secret.yaml
+++ b/charts/qalita/templates/seaweedfs-s3-secret.yaml
@@ -1,12 +1,32 @@
 {{- if .Values.seaweedfs.enabled }}
+{{- /*
+  Les quatre identifiants passent par `qalita.preservedSecret` : un déploiement
+  qui ne les fournit pas réutilise ceux déjà en cluster, et s'arrête net s'il
+  n'y en a aucun. La version précédente recopiait `.Values.backend.s3.*` tel
+  quel — or ces clés valent "" dans les fichiers de values du parc, qui sont des
+  emplacements remplis au déploiement. Un `helm upgrade -f <values>` sans
+  injection réécrivait donc les quatre identifiants à vide, sans erreur.
+
+  Pas de `generate` ici, volontairement : contrairement à un mot de passe
+  interne, ces clés doivent être connues des clients S3 (le backend, mais aussi
+  les agents). En fabriquer une au hasard produirait un déploiement « réussi »
+  avec un stockage inaccessible. Mieux vaut échouer et réclamer la valeur.
+
+  `seaweedfs_s3_config` est dérivé des mêmes variables : les deux moitiés du
+  Secret ne peuvent donc plus diverger.
+*/}}
+{{- $adminId     := include "qalita.preservedSecret" (dict "ctx" $ "secret" "seaweedfs-s3-secret" "key" "admin_access_key_id"     "value" .Values.backend.s3.admin_access_key_id) }}
+{{- $adminSecret := include "qalita.preservedSecret" (dict "ctx" $ "secret" "seaweedfs-s3-secret" "key" "admin_secret_access_key" "value" .Values.backend.s3.admin_secret_access_key) }}
+{{- $readId      := include "qalita.preservedSecret" (dict "ctx" $ "secret" "seaweedfs-s3-secret" "key" "read_access_key_id"      "value" .Values.backend.s3.read_access_key_id) }}
+{{- $readSecret  := include "qalita.preservedSecret" (dict "ctx" $ "secret" "seaweedfs-s3-secret" "key" "read_secret_access_key"  "value" .Values.backend.s3.read_secret_access_key) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: seaweedfs-s3-secret
 stringData:
-  admin_access_key_id: '{{ .Values.backend.s3.admin_access_key_id }}'
-  admin_secret_access_key: '{{ .Values.backend.s3.admin_secret_access_key }}'
-  read_access_key_id: '{{ .Values.backend.s3.read_access_key_id }}'
-  read_secret_access_key: '{{ .Values.backend.s3.read_secret_access_key }}'
-  seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"{{.Values.backend.s3.admin_access_key_id }}","secretKey":"{{.Values.backend.s3.admin_secret_access_key }}"}],"actions":["Admin","Read","Write","List","Tagging"]},{"name":"anvReadOnly","credentials":[{"accessKey":"{{.Values.backend.s3.read_access_key_id }}","secretKey":"{{.Values.backend.s3.read_secret_access_key }}"}],"actions":["Read"]}]}'
+  admin_access_key_id: '{{ $adminId }}'
+  admin_secret_access_key: '{{ $adminSecret }}'
+  read_access_key_id: '{{ $readId }}'
+  read_secret_access_key: '{{ $readSecret }}'
+  seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"{{ $adminId }}","secretKey":"{{ $adminSecret }}"}],"actions":["Admin","Read","Write","List","Tagging"]},{"name":"anvReadOnly","credentials":[{"accessKey":"{{ $readId }}","secretKey":"{{ $readSecret }}"}],"actions":["Read"]}]}'
 {{- end }}


### PR DESCRIPTION
## Ce qui s'est passé

Le 2026-08-17, un `helm upgrade` de `qalita-platform-demo` lancé avec le seul fichier de values a détruit **deux** Secrets, sans la moindre erreur. La commande a rapporté `STATUS: deployed`.

**`seaweedfs-s3-secret`** — les quatre identifiants réécrits à **vide**. Les fichiers `platform/*-values.yaml` déclarent `backend.s3.*: ""` : ce sont des emplacements que le pipeline remplit au déploiement, et le template les recopiait tels quels. Le backend est ensuite tombé en boucle :

```
InvalidAccessKeyId — The access key ID you provided does not exist in our records
30 tentatives, puis « S3 is not accessible after 30 attempts. Buckets will not be created. »
```

La passerelle S3 ne relisant sa configuration qu'au démarrage, elle rejetait une clé que le Secret ne contenait déjà plus.

**`qalita-qalita-secret`** — `secretKey`, qui signe les JWT, et `adminPassword` **regénérés aléatoirement**. Ils étaient rendus ainsi :

```
adminPassword: {{ default (randAlphaNum 25 | b64enc) .Values.backend.adminPassword | b64enc }}
secretKey:     {{ default (randAlphaNum 512 | b64enc) .Values.backend.secretKey | b64enc }}
```

Deux défauts dans cette seule ligne. Le tirage était refait à **chaque rendu**, donc tout upgrade ne fournissant pas ces valeurs les rotait en silence — invalidant les sessions en cours. Et le `| b64enc` interne s'ajoutait à celui de fin : la valeur générée était encodée **deux fois**. Trace mesurée pendant l'incident, `secretKey` est passé de 33 à 684 octets après décodage simple. Une valeur fournie, elle, n'était encodée qu'une fois — les deux chemins ne produisaient pas le même genre de contenu.

`licenseKey`, dans ce même Secret, avait déjà le bon motif (`lookup` puis réutilisation) et **a traversé l'incident intact**. Cette PR généralise ce motif au lieu de le laisser à un seul champ.

## Le correctif

`qalita.preservedSecret` résout chaque champ dans cet ordre :

1. la valeur fournie, si non vide — la déclaration prime toujours ;
2. sinon la valeur **déjà présente en cluster** — un déploiement qui ne fournit pas un secret ne doit jamais en détruire un ;
3. sinon un `default` explicite — c'est ce qui préserve le repli `unlicenced` de `licenseKey` ;
4. sinon un tirage aléatoire si `generate` — donc au premier déploiement seulement ;
5. sinon **`fail`**, en citant le champ.

Pas de `generate` pour les clés S3, volontairement : contrairement à un mot de passe interne, elles doivent être connues des clients — le backend, mais aussi les agents. En fabriquer une au hasard produirait un déploiement « réussi » avec un stockage inaccessible. Mieux vaut s'arrêter et réclamer la valeur.

`seaweedfs_s3_config` est désormais dérivé des mêmes variables que les quatre champs : les deux moitiés du Secret ne peuvent plus diverger. Et le passage à `stringData` fait que l'encodage n'a plus lieu qu'à un seul endroit, celui de Kubernetes.

## Vérifications

**Valeurs fournies** — rendues telles quelles, et `seaweedfs_s3_config` reprend bien les mêmes :

```
admin_access_key_id: 'ADMIN_ID_TEST'
seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"ADMIN_ID_TEST",…
adminPassword: "MOTDEPASSE_TEST"
```

**Valeurs vides, hors cluster** — la commande exacte qui a causé l'incident échoue désormais :

```
Error: execution error at (qalita/templates/seaweedfs-s3-secret.yaml:18:20):
Secret seaweedfs-s3-secret : le champ admin_access_key_id est vide et aucune valeur
existante n'a ete trouvee dans le namespace default. Fournissez-le (pipeline,
Infisical, --set) plutot que de deployer avec un emplacement vide : ecrire une
valeur vide ici casserait l'authentification.
```

**Préservation** — c'est le chemin qui compte, et il est le plus difficile à tester : `lookup` renvoie vide sous `helm template` **comme sous `--dry-run`**. Je l'ai donc vérifié avec un chart jetable, installé pour de vrai dans `qalita-platform-dev`, n'écrivant aucun secret et ne rendant que la **longueur** de la valeur résolue :

```
{"longueur_resolue":"20","provenance":"lookup"}
```

Soit exactement la clé existante, récupérée alors que la valeur fournie était vide. Sonde désinstallée ensuite, Secret de dev vérifié inchangé.

## Ce que cette PR ne fait pas

Elle **ne répare pas** `qalita-platform-demo`, dont les deux Secrets restent à restaurer depuis la révision 44. Elle empêche la récidive — et c'est le point important, car `platform/prod-values.yaml` porte exactement les mêmes emplacements vides : un `helm upgrade -f` sans injection y aurait le même effet.

## Conséquence à connaître

`helm template` et `helm upgrade --dry-run` sur un chart sans identifiants échouent maintenant au lieu de rendre du vide. C'est voulu, et le message dit quoi faire. Si un pipeline valide le chart par un dry-run sans secrets, il faudra lui en fournir — y compris factices — ou cibler un namespace où le Secret existe déjà.
