### PR TITLE
fix(postgres18): verrou du secret, deux gardes manquantes, et le gel absent du runbook

### DIFF
--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -8,7 +8,7 @@ name: "qalita"
 # (décision propriétaire 2026-08-17 : couverture Longhorn, restauration
 # exercée). Le schéma de values et les notes de migration sont dans
 # values.schema.json et README.md.
-version: "3.0.1"
+version: "3.0.2"
 icon: https://avatars.githubusercontent.com/u/101010687?s=48&v=4
 appVersion: "2.18.0"
 home: https://qalita.io

--- a/charts/qalita/templates/_helpers.tpl
+++ b/charts/qalita/templates/_helpers.tpl
@@ -86,7 +86,7 @@ ATTENTION AU MODE `helm template`. `lookup` y renvoie toujours vide : l'étape 2
 est donc inopérante, et un rendu hors cluster avec des values vides tombera en
 3 ou en 4. C'est voulu — `helm template` sert à inspecter, pas à déployer — mais
 cela veut dire qu'un test de non-régression sur la préservation doit passer par
-`helm upgrade --dry-run`, seul mode où `lookup` interroge réellement l'API.
+`helm upgrade --dry-run=server`, seul mode où `lookup` interroge réellement l'API.
 
 Arguments (dict) :
   ctx       le contexte racine ($)

--- a/charts/qalita/templates/backend-deployment.yaml
+++ b/charts/qalita/templates/backend-deployment.yaml
@@ -60,6 +60,18 @@ spec:
             d'un serveur à l'autre : seuls l'hôte et la source du mot de passe
             bougent.
           */}}
+          {{- /*
+            DEUX GARDES, chacune contre un manifest qui reste COHÉRENT EN
+            APPARENCE alors que l'application ne peut pas fonctionner. Ajoutées
+            le 2026-08-18 après revue, avant le premier déploiement du 18 ;
+            leur absence a déjà coûté une revue chez previly.
+          */}}
+          {{- if and .Values.postgres18.serveApp (not .Values.postgres18.enabled) }}
+          {{- fail "postgres18.serveApp=true exige postgres18.enabled=true. Sans cette garde le rendu réussit et le backend reste SILENCIEUSEMENT sur bitnami : on croit la bascule faite, on enchaîne l'étape 4 du runbook (bitnami à l'échelle 0) puis l'étape 5 (destruction du volume) — et ce volume porte encore les seules données." }}
+          {{- end }}
+          {{- if and (not .Values.postgresql.enabled) (not (and .Values.postgres18.enabled .Values.postgres18.serveApp)) }}
+          {{- fail "aucun serveur PostgreSQL ne sert l'application : postgresql.enabled=false alors que le 18 ne prend pas le relais. Le backend pointerait sur le secret qalita-postgresql que le sous-chart désactivé ne rend plus, avec optional: false — CreateContainerConfigError, le pod ne démarre jamais. En CI --atomic finit par le rattraper au bout de dix minutes ; un helm upgrade lancé à la main laisse l'application morte." }}
+          {{- end }}
           {{- $pgHost := printf "%s-postgresql" .Release.Name }}
           {{- $pgSecret := printf "%s-postgresql" .Release.Name }}
           {{- if and .Values.postgres18.enabled .Values.postgres18.serveApp }}

--- a/charts/qalita/templates/postgres18-statefulset.yaml
+++ b/charts/qalita/templates/postgres18-statefulset.yaml
@@ -36,6 +36,26 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: qalita-postgres18
+  annotations:
+    # SANS CETTE ANNOTATION, LE VOLUME DEVIENT DÉFINITIVEMENT INACCESSIBLE.
+    # Ce Secret et le PVC du StatefulSet n'ont pas la même durée de vie : le
+    # PVC vient de volumeClaimTemplates, que ni Helm ni Kubernetes ne ramassent
+    # jamais, alors que le Secret appartient à la révision. Un
+    # `helm upgrade --atomic` qui échoue (le pipeline en pose un, timeout 10 min)
+    # revient à une révision où ce Secret n'existait pas : Helm le SUPPRIME, le
+    # volume reste. Au déploiement suivant, `lookup` ne trouve plus rien et
+    # qalita.preservedSecret régénère un mot de passe — pendant que l'entrypoint
+    # de postgres, voyant un data dir déjà initialisé, SAUTE initdb et laisse au
+    # rôle l'ancien. Secret et rôle divergent sans qu'aucun manifest ne
+    # paraisse anormal : `password authentication failed for user "qalita"`,
+    # sans retour possible par les values. Même chaîne si l'on repasse
+    # postgres18.enabled à false puis à true.
+    # Trouvé en revue le 2026-08-18, avant le premier déploiement du 18.
+    # Si le cas s'est déjà produit, deux sorties : `helm get manifest qalita
+    # -n <ns> --revision <N>` rend l'ancien mot de passe en clair, ou bien
+    # `kubectl exec … psql -U qalita` (l'entrypoint écrit `local all all trust`)
+    # puis ALTER ROLE pour réaligner sur le Secret courant.
+    helm.sh/resource-policy: keep
 stringData:
   password: {{ $pgPassword | quote }}
 ---

--- a/charts/qalita/values.yaml
+++ b/charts/qalita/values.yaml
@@ -251,14 +251,30 @@ postgresql:
 # migration (phase 11c) :
 #   0. filet : snapshot/backup Longhorn du PVC bitnami juste avant
 #   1. postgres18.enabled: true          -> le serveur 18 démarre, vide
-#   2. dump/restore ONE-SHOT (jamais pg_upgrade) :
+#   2. GELER LES ÉCRITURES : backend et worker à l'échelle 0, et les y laisser
+#      jusqu'à la fin de l'étape 3. Ce n'est pas une précaution de confort,
+#      c'est ce qui rend le dump exact ET ce qui empêche une double écriture :
+#      le déploiement du backend est en RollingUpdate par défaut (aucune
+#      `strategy` déclarée), donc à la bascule l'ANCIEN pod — encore branché
+#      sur bitnami — et le NOUVEAU — branché sur le 18 — coexistent le temps du
+#      rollout. Sans gel, les écritures de cette fenêtre se répartissent entre
+#      DEUX bases, et aucune des deux n'est ensuite complète.
+#   3. dump/restore ONE-SHOT (jamais pg_upgrade), app toujours à 0 :
 #        kubectl exec <pod bitnami> -- pg_dump --no-owner --no-acl … \
 #          | kubectl exec -i <pod postgres18> -- psql …
-#   3. postgres18.serveApp: true         -> le backend bascule (repointage)
-#   4. sous-chart bitnami à l'échelle 0, volume INTACT plusieurs jours
-#   5. postgresql.enabled: false         -> seulement après période nominale
-# Retour arrière à toute étape : serveApp false — l'ancien serveur n'a jamais
-# bougé.
+#      Restaurer sous `psql -v ON_ERROR_STOP=1` : sans lui psql avale les
+#      erreurs et rend une base à moitié peuplée qui a l'air correcte.
+#      Vérifier ensuite les comptes de lignes TABLE PAR TABLE contre la source
+#      — un simple compte de tables ne prouve rien (chez previly, un backend
+#      transitoire avait semé un schéma-leurre au bon nombre de tables, toutes
+#      vides, qui a failli passer pour la restauration).
+#   4. postgres18.serveApp: true         -> le backend bascule (repointage),
+#      puis re-scaler l'application et vérifier.
+#   5. sous-chart bitnami à l'échelle 0, volume INTACT plusieurs jours
+#   6. postgresql.enabled: false         -> seulement après période nominale
+# Retour arrière jusqu'à l'étape 5 : serveApp false — l'ancien serveur n'a
+# jamais bougé. APRÈS l'étape 6 il en faut DEUX (postgresql.enabled=true ET
+# serveApp=false) ; la garde du gabarit backend refuse la moitié du geste.
 postgres18:
   enabled: false
   # true = le backend vise qalita-postgres18 (service et secret) au lieu du


### PR DESCRIPTION
Quatre défauts trouvés en revue **avant le premier déploiement du serveur 18**, chacun revérifié à la main par rendu réel plutôt que sur parole.

## 1. Le Secret n'avait pas `resource-policy: keep` — et sans lui le volume devient définitivement inaccessible

Le Secret et le PVC **n'ont pas la même durée de vie**. Le PVC vient de `volumeClaimTemplates`, que ni Helm ni Kubernetes ne ramassent jamais ; le Secret, lui, appartient à la révision.

Le pipeline pose un `helm upgrade --atomic --timeout 10m`. À la première révision du 18, un échec de readiness de **n'importe quelle** ressource de la release déclenche un rollback vers une révision où ce Secret n'existait pas : Helm le supprime, le volume reste. Au déploiement suivant, `lookup` ne trouve plus rien et le helper **régénère** un mot de passe — pendant que l'entrypoint de postgres, voyant un data dir déjà initialisé, **saute initdb** et laisse au rôle l'ancien.

Secret et rôle divergent sans qu'aucun manifest ne paraisse anormal : `password authentication failed for user "qalita"`, sans retour possible par les values.

*Vérifié* : ce Secret ne portait aucune annotation, et `resource-policy` n'apparaissait **nulle part** dans le chart.

## 2 et 3. Deux gardes `fail` manquantes

Toutes deux rendaient **sans erreur** — je les ai reproduites :

| combinaison | ce que le rendu produisait |
|---|---|
| `serveApp=true` + `enabled=false` | `POSTGRESQL_SERVER=qalita-postgresql` — **la bascule est silencieusement ignorée** |
| `postgresql.enabled=false` sans repreneur | backend pointant sur le secret `qalita-postgresql` que le sous-chart désactivé ne produit plus, `optional: false` |

La première est la plus dangereuse : on croit la bascule faite, on enchaîne la mise à l'échelle 0 de bitnami puis la destruction de son volume — **qui porte encore les seules données**. La seconde donne un `CreateContainerConfigError` ; en CI `--atomic` le rattrape au bout de dix minutes, mais un `helm upgrade` lancé à la main laisse l'application morte.

## 4. Le runbook n'avait aucune étape de gel

Elle est ajoutée **avec sa vraie justification** : le déploiement du backend n'a pas de `strategy` déclarée, donc RollingUpdate. À la bascule, l'**ancien** pod (encore sur bitnami) et le **nouveau** (sur le 18) coexistent le temps du rollout — les écritures de cette fenêtre se répartissent entre **deux bases**, dont aucune n'est ensuite complète.

Le runbook gagne aussi `ON_ERROR_STOP` à la restauration, et la vérification des comptes **table par table** : un simple compte de tables ne prouve rien — un schéma-leurre au bon nombre de tables, toutes vides, a failli passer pour une restauration chez previly cette semaine.

## Au passage

Le commentaire du helper prescrivait `helm upgrade --dry-run` comme « seul mode où `lookup` interroge l'API ». **Faux depuis Helm 3.13** — ni `template` ni `--dry-run` client ne contactent l'API, il faut `--dry-run=server`, et le pipeline épingle 3.18.2. Quelqu'un jouant le test prescrit verrait un mot de passe différent de celui du cluster, conclurait que la préservation est cassée, et « corrigerait » en figeant une valeur dans les values — soit exactement le verrouillage du point 1.

## Vérification

| configuration | attendu | obtenu |
|---|---|---|
| `serveApp` sans `enabled` | échec | ✓ échoue |
| bitnami coupé, rien ne sert | échec | ✓ échoue |
| dev, 18 à côté | rend | ✓ |
| dev basculé | rend | ✓ |
| bitnami coupé, 18 sert | rend | ✓ |
| bitnami seul (demo/prod) | rend | ✓ |

`helm lint` propre. Le Secret rendu porte bien `{'helm.sh/resource-policy': 'keep'}`.