### PR TITLE
chore(worker): default the worker image to cli 2.18.3

### DIFF
--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -8,7 +8,7 @@ name: "qalita"
 # (décision propriétaire 2026-08-17 : couverture Longhorn, restauration
 # exercée). Le schéma de values et les notes de migration sont dans
 # values.schema.json et README.md.
-version: "3.0.3"
+version: "3.0.4"
 icon: https://avatars.githubusercontent.com/u/101010687?s=48&v=4
 appVersion: "2.18.0"
 home: https://qalita.io

--- a/charts/qalita/README.md
+++ b/charts/qalita/README.md
@@ -135,6 +135,30 @@ With `cluster.domain`=**example.com**  Creates the following endpoints:
 
 # Upgrading
 
+## To chart 3.0.4 — required to run analysis packs
+
+The worker image default moves to `cli` **2.18.3**. Earlier images cannot run
+packs at all:
+
+- `uv`, which every pack's `run.sh` needs to install its dependencies, was
+  missing from the image, and the fallback that bootstrapped it is refused
+  inside the image's virtualenv. Every job failed with `uv: not found`.
+- The image shipped only CPython 3.14, so packs that cap `requires-python`
+  below it found no interpreter, and dependencies with no 3.14 wheels could not
+  be installed — the runtime carries no compiler. 2.18.3 runs packs on 3.13 and
+  also ships 3.11 and 3.12.
+
+Upgrading the chart is enough unless you pin `worker.image` in your own
+`values.yaml`, in which case set the tag there too:
+
+```bash
+helm repo update
+helm upgrade qalita qalita/qalita -f values.yaml
+```
+
+Worker pods must be restarted to pick the new image up; the chart's rollout
+does that for you.
+
 ## To chart 2.18.0 — required if you are on 2.17.0 or older
 
 The worker image moved from the pre-rename package `qalita-cli` to `cli`:
@@ -248,7 +272,7 @@ upstream and can be restored to the client registry on request.
 | worker.mode | string | `worker` | Qalita Worker mode <job/worker> |
 | worker.token | string | `changeme` | Qalita Worker API Token |
 | worker.image.repository | string | `ghcr.io/qalita/cli` | QALITA Worker image (GitHub Container Registry) |
-| worker.image.tag | string | `2.18.0` | QALITA Worker Image Tag |
+| worker.image.tag | string | `2.18.3` | QALITA Worker Image Tag |
 | worker.image.pullPolicy | string | `IfNotPresent` | QALITA Worker Image Pull Policy |
 | worker.replicaCount | int | `1` | QALITA Worker Replica Count |
 | worker.deployment.extraEnv | list | `[]` | QALITA Worker Deployment Environment Variables, format : `- name: QALITA_ENV value: "PROD"` |

--- a/charts/qalita/values.yaml
+++ b/charts/qalita/values.yaml
@@ -188,7 +188,7 @@ worker:
     # ghcr.io/qalita/cli (first one 2.16.4), which is also what the client
     # registry mirrors, so the default follows the current package.
     repository: ghcr.io/qalita/cli
-    tag: "2.18.0"
+    tag: "2.18.3"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
> ⚠️ **À merger après le push du tag `cli` 2.18.3**, pour que la valeur par défaut ne pointe jamais vers une image inexistante.

## Pourquoi

Les images worker antérieures **ne peuvent pas exécuter de pack**, quel qu'il soit. Deux causes, corrigées par qalita/cli#139 et qalita/cli#140 :

- `uv` — dont le `run.sh` de chaque pack a besoin pour installer ses dépendances — était absent de l'image, et le repli qui l'installait est refusé par pip à l'intérieur du virtualenv de l'image. Tous les jobs mouraient sur `uv: not found`.
- L'image ne fournissait que CPython 3.14 : les packs qui plafonnent leur `requires-python` en dessous ne trouvaient aucun interpréteur, et les dépendances sans wheel 3.14 ne pouvaient pas s'installer, le runtime durci ne portant aucun compilateur.

Constaté en production chez un client (CHU de Montpellier) : aucun pack ne tournait.

`cli` 2.18.3 embarque `uv`, exécute les packs sur 3.13, et fournit 3.11 et 3.12 pour les packs qui plafonnent plus bas.

## Contenu

Seul le pin du worker bouge — `backend`, `frontend` et `doc` restent sur leur propre release 2.18.0 :

| | Avant | Après |
|---|---|---|
| `worker.image.tag` | `2.18.0` | `2.18.3` |
| Version du chart | `3.0.3` | `3.0.4` |

Plus une note de montée de version dans le README, suivant la convention de la section « To chart 2.18.0 » déjà présente.

`helm lint` passe (le seul avertissement, sur les sous-charts `postgresql`/`seaweedfs` non vendorisés, préexiste et n'est pas lié).

## Note

Un déploiement par Docker Compose n'est pas concerné par cette PR : il tire l'image directement et n'a qu'à passer sur `2.18.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)