### PR TITLE
chore(worker): default the worker image to cli 2.18.4

### DIFF
--- a/charts/qalita/Chart.yaml
+++ b/charts/qalita/Chart.yaml
@@ -8,7 +8,7 @@ name: "qalita"
 # (décision propriétaire 2026-08-17 : couverture Longhorn, restauration
 # exercée). Le schéma de values et les notes de migration sont dans
 # values.schema.json et README.md.
-version: "3.0.4"
+version: "3.0.5"
 icon: https://avatars.githubusercontent.com/u/101010687?s=48&v=4
 appVersion: "2.18.0"
 home: https://qalita.io

--- a/charts/qalita/values.yaml
+++ b/charts/qalita/values.yaml
@@ -188,7 +188,7 @@ worker:
     # ghcr.io/qalita/cli (first one 2.16.4), which is also what the client
     # registry mirrors, so the default follows the current package.
     repository: ghcr.io/qalita/cli
-    tag: "2.18.3"
+    tag: "2.18.4"
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
Follows the 2.18.4 release (cli #142).

Handlers run inline in the gRPC incoming loop, so while a job ran nothing was read off the stream and `_last_message_received` could not advance — the health check mistook the worker's own silence for an unresponsive server. Every job outliving the 45s timeout cancelled its own stream, the worker reconnected mid-job, and the backend reassigned the job. That is the duplicate-execution mechanism reported from the field.

`worker.image.tag` 2.18.3 → 2.18.4, chart 3.0.4 → 3.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5nB27TuxtwUxRq9dtMiEp